### PR TITLE
Check for 'Site Status' in Coming Soon Toggle Functions

### DIFF
--- a/tests/cypress/integration/coming-soon.cy.js
+++ b/tests/cypress/integration/coming-soon.cy.js
@@ -18,7 +18,7 @@ describe('Coming Soon', function () {
 			.contains('span', 'Coming Soon')
 			.should('be.visible');
 
-		cy.get( appClass + '-app-settings-coming-soon').contains('h3', 'Maintenance Mode')
+		cy.get( appClass + '-app-settings-coming-soon').contains('h3', 'Site Status')
 			.scrollIntoView()
 			.should('be.visible');
 


### PR DESCRIPTION
This is part of this PR: https://github.com/bluehost/bluehost-wordpress-plugin/pull/706

We are changing the coming soon section title from 'Maintenance Mode' to 'Site Status: ${status}'.