### PR TITLE
Disable coming soon after onboarding if the user didn't opt-in

### DIFF
--- a/includes/ComingSoon.php
+++ b/includes/ComingSoon.php
@@ -49,6 +49,7 @@ class ComingSoon {
 		// set up all actions
 		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
 		\add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+		\add_action( 'newfold/onboarding/completed', array( $this, 'handle_onboarding_completed' ) );
 		\add_action( 'admin_notices', array( $this, 'notice_display' ) );
 		\add_action( 'admin_bar_menu', array( $this, 'add_tool_bar_item' ), 100 );
 		\add_action( 'template_redirect', array( $this, 'maybe_load_template' ) );
@@ -79,6 +80,21 @@ class ComingSoon {
 	 */
 	public function rest_api_init() {
 		new API\ComingSoon();
+	}
+
+	/**
+	 * Handle the onboarding complete action.
+	 * When the onboarding is complete, disable the coming soon page if the user has not opted in.
+	 * 
+	 * @return void
+	 */
+	public function handle_onboarding_completed() {
+		$coming_soon_service = container()->get( 'comingSoon' );
+
+		$coming_soon_last_changed = $coming_soon_service->get_last_changed_timestamp();
+		if ( ! $coming_soon_last_changed ) {
+			$coming_soon_service->disable();
+		}
 	}
 
 	/**

--- a/includes/Service.php
+++ b/includes/Service.php
@@ -52,7 +52,7 @@ class Service
 	 *
 	 * @return void
 	 */
-	public function last_changed_timestamp() {
+	private function last_changed_timestamp() {
 		update_option( 'nfd_coming_soon_last_changed', time() );
 	}
 

--- a/includes/Service.php
+++ b/includes/Service.php
@@ -17,8 +17,12 @@ class Service
 	 *
 	 * @return void
 	 */
-	public function enable() {
+	public function enable( $timestamp = true ) {
 		update_option( 'nfd_coming_soon', 'true' );
+
+		if ( $timestamp ) {
+			$this->last_changed_timestamp();
+		}
 	}
 
 	/**
@@ -26,8 +30,12 @@ class Service
 	 *
 	 * @return void
 	 */
-	public function disable() {
+	public function disable( $timestamp = true ) {
 		update_option( 'nfd_coming_soon', 'false' );
+
+		if ( $timestamp ) {
+			$this->last_changed_timestamp();
+		}
 	}
 
 	/**
@@ -37,5 +45,34 @@ class Service
 	 */
 	public function is_enabled() {
 		return 'true' === get_option( 'nfd_coming_soon', 'false' );
+	}
+
+	/**
+	 * Create/update the last changed timestamp.
+	 *
+	 * @return void
+	 */
+	public function last_changed_timestamp() {
+		update_option( 'nfd_coming_soon_last_changed', time() );
+	}
+
+	/**
+	 * Get the last changed timestamp.
+	 *
+	 * @return int
+	 */
+	public function get_last_changed_timestamp( $as_date = false ) {
+		$timestamp = get_option( 'nfd_coming_soon_last_changed' );
+
+		if ( ! $timestamp ) {
+			return false;
+		}
+
+		// If requested as date convert and return.
+		if ( $as_date ) {
+			return date( 'Y-m-d H:i:s', $timestamp );
+		}
+
+		return $timestamp;
 	}
 }

--- a/static/js/coming-soon.js
+++ b/static/js/coming-soon.js
@@ -10,6 +10,7 @@
 			isEnabled: checkComingSoonStatus,
 			enable: enableComingSoon,
 			disable: disableComingSoon,
+			lastChanged: getLastChanged,
 		};
 	};
 
@@ -79,6 +80,28 @@
 			} );
 
 		return result;
+	};
+
+	const getLastChanged = async () => {
+		let value;
+
+		await window.wp
+			.apiFetch( {
+				url: `${ API_ENDPOINT }/last-changed`,
+				method: 'GET',
+			} )
+			.then( ( response ) => {
+				if ( response.hasOwnProperty( 'lastChanged' ) ) {
+					value = response.lastChanged;
+				} else {
+					value = null;
+				}
+			} )
+			.catch( () => {
+				value = null;
+			} );
+
+		return value;
 	};
 
 	window.addEventListener( 'DOMContentLoaded', () => {

--- a/upgrades/1.1.14.php
+++ b/upgrades/1.1.14.php
@@ -14,6 +14,6 @@ add_action( 'newfold_container_set', function () {
 	$isFreshInstall = container()->has( 'isFreshInstallation' ) ? container()->get( 'isFreshInstallation' ) : false;
 	if ( $isFreshInstall ) {
 		$comingSoonService = new Service();
-		$comingSoonService->enable();
+		$comingSoonService->enable( false );
 	}
 } );


### PR DESCRIPTION
After onboarding fires `newfold/onboarding/completed`, we'll check if the user has interacted/opted-in. If they didn't, we'll disable the coming soon and set a timestamp.

This PR also exposes the 'last changed timestamp' value in both the container's service provider and the JS API.

#### Example

Service Provider:
```php
$coming_soon_service = container()->get( 'comingSoon' );
$coming_soon_service->get_last_changed_timestamp(); // returns Unix timestamp
// or 
$coming_soon_service->get_last_changed_timestamp( true ); // returns date formatted timestamp
```

JavaScript API:
```JavaScript
await NewfoldRuntime.comingSoon.lastChanged(); 
// returns date formatted timestamp, false if empty or null on error
``` 

This PR addresses part of this internal ticket: https://jira.newfold.com/browse/PRESS2-1505