### PR TITLE
TEST workflow with secondary module and branch

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -44,7 +44,7 @@ jobs:
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-hostgator'
       secondary-module-repo: 'newfold-labs/wp-module-ecommerce'
-      secondary-module-branch: 'main'
+      secondary-module-branch: 'tags/v1.3.19'
     secrets: inherit
 
   web:
@@ -56,6 +56,7 @@ jobs:
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-web'
       secondary-module-repo: 'newfold-labs/wp-module-data'
+      secondary-module-branch: 'main'
     secrets: inherit
 
   crazydomains:
@@ -66,7 +67,8 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-crazy-domains'
-      secondary-module-branch: 'expect-to-be-skipped'
+      secondary-module-repo: 'newfold-labs/wp-module-data'
+      secondary-module-branch: 'tags/2.4.18'
     secrets: inherit
 
   mojo:
@@ -78,5 +80,5 @@ jobs:
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-mojo'
       secondary-module-repo: 'newfold-labs/wp-module-data'
-      secondary-module-branch: 'expect-to-fail'
+      secondary-module-branch: 'expect-to-fail-no-branch-match-found'
     secrets: inherit

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -38,7 +38,7 @@ jobs:
   hostgator:
     name: HostGator Build and Test
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@add/secondary-module-inputs
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -48,7 +48,7 @@ jobs:
   web:
     name: Web.com Build and Test
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@add/secondary-module-inputs
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -58,7 +58,7 @@ jobs:
   crazydomains:
     name: Crazy Domains Build and Test
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@add/secondary-module-inputs
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -68,7 +68,7 @@ jobs:
   mojo:
     name: Mojo Build and Test
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@add/secondary-module-inputs
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -26,11 +26,13 @@ jobs:
   bluehost:
     name: Bluehost Build and Test
     needs: setup
-    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@main
+    uses: newfold-labs/workflows/.github/workflows/module-plugin-test.yml@add/secondary-module-inputs
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
+      secondary-module-repo: 'newfold-labs/wp-module-onboarding'
+      secondary-module-branch: 'enhance/ai-onboarding'
     secrets: inherit
 
   hostgator:

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -43,6 +43,8 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-hostgator'
+      secondary-module-repo: 'newfold-labs/wp-module-ecommerce'
+      secondary-module-branch: 'main'
     secrets: inherit
 
   web:
@@ -53,6 +55,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-web'
+      secondary-module-repo: 'newfold-labs/wp-module-data'
     secrets: inherit
 
   crazydomains:
@@ -63,6 +66,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-crazy-domains'
+      secondary-module-branch: 'expect-to-be-skipped'
     secrets: inherit
 
   mojo:
@@ -73,4 +77,6 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-mojo'
+      secondary-module-repo: 'newfold-labs/wp-module-data'
+      secondary-module-branch: 'expect-to-fail'
     secrets: inherit

--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -43,8 +43,8 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-hostgator'
-      secondary-module-repo: 'newfold-labs/wp-module-ecommerce'
-      secondary-module-branch: 'tags/v1.3.19'
+      secondary-module-repo: 'newfold-labs/wp-module-onboarding'
+      secondary-module-branch: 'enhance/ai-onboarding'
     secrets: inherit
 
   web:
@@ -55,8 +55,6 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-web'
-      secondary-module-repo: 'newfold-labs/wp-module-data'
-      secondary-module-branch: 'main'
     secrets: inherit
 
   crazydomains:
@@ -67,8 +65,8 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-crazy-domains'
-      secondary-module-repo: 'newfold-labs/wp-module-data'
-      secondary-module-branch: 'tags/2.4.18'
+      secondary-module-repo: 'newfold-labs/wp-module-onboarding'
+      secondary-module-branch: 'enhance/ai-onboarding'
     secrets: inherit
 
   mojo:
@@ -79,6 +77,4 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'newfold-labs/wp-plugin-mojo'
-      secondary-module-repo: 'newfold-labs/wp-module-data'
-      secondary-module-branch: 'expect-to-fail-no-branch-match-found'
     secrets: inherit


### PR DESCRIPTION
This is a test PR to verify the functionality of our test workflow.

DO NOT MERGE

This asserts the module-plugin-test workflow should be used at `add/secondary-module-inputs`
It sends the onboarding module as the secondary module.
It sends the enhance/ai-onboarding branch for the secondary module.

I want to verify that the secondary module is updated to that branch and that tests run.

Afterward, I will also test without the secondary inputs to ensure adding them doesn't break existing workflows.