### PR TITLE
Test integration updates

### DIFF
--- a/.github/workflows/brand-plugin-test.yml
+++ b/.github/workflows/brand-plugin-test.yml
@@ -31,6 +31,7 @@ jobs:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
       plugin-repo: 'bluehost/bluehost-wordpress-plugin'
+      plugin-branch: 'release/3.9.0'
     secrets: inherit
 
   hostgator:

--- a/tests/cypress/integration/coming-soon.cy.js
+++ b/tests/cypress/integration/coming-soon.cy.js
@@ -4,18 +4,19 @@ describe( 'Coming Soon', function () {
 	const appClass = '.' + Cypress.env( 'appId' );
 
 	before( () => {
-		// Set coming soon to true
+		// Set coming soon option to true to start with
 		cy.exec( `npx wp-env run cli wp option update mm_coming_soon true` );
-		cy.exec( `npx wp-env run cli wp option update nfd_coming_soon true` );
+		cy.exec( `npx wp-env run cli wp option update nfd_coming_soon true` );		
+	} );
 
+	it( 'Coming Soon is active', () => {
 		cy.visit(
 			'/wp-admin/admin.php?page=' +
 				Cypress.env( 'pluginId' ) +
 				'#/settings'
 		);
-	} );
+		cy.reload();
 
-	it( 'Coming Soon Toggle Functions', () => {
 		// Initial Coming Soon State
 		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-coming-soon' )
 			.scrollIntoView()
@@ -34,35 +35,7 @@ describe( 'Coming Soon', function () {
 		cy.get( '[data-id="coming-soon-toggle"]' )
 			.should( 'have.attr', 'aria-checked' )
 			.and( 'include', 'true' );
-
-		// Deactivate coming soon - Launch Site
-		cy.get( '[data-id="coming-soon-toggle"]' ).click();
-		cy.wait( 500 );
-
-		cy.get( '[data-id="coming-soon-toggle"]' )
-			.should( 'have.attr', 'aria-checked' )
-			.and( 'include', 'false' );
-		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-live' )
-			.scrollIntoView()
-			.should( 'be.visible' );
-		cy.get( '.nfd-notifications' )
-			.contains( '.nfd-notification', 'Coming soon deactivated' )
-			.should( 'be.visible' );
-
-		// Activate Coming Soon - Unlaunch Site
-		cy.get( '[data-id="coming-soon-toggle"]' ).click();
-		cy.wait( 500 );
-
-		cy.get( '[data-id="coming-soon-toggle"]' )
-			.should( 'have.attr', 'aria-checked' )
-			.and( 'include', 'true' );
-		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-coming-soon' )
-			.scrollIntoView()
-			.should( 'be.visible' );
-		cy.get( '.nfd-notifications' )
-			.contains( '.nfd-notification', 'Coming soon activated' )
-			.should( 'be.visible' );
-	} );
+	});
 
 	it( 'Displays Coming Soon in Site Status Admin Toolbar', () => {
 		// Admin bar contains label
@@ -96,6 +69,67 @@ describe( 'Coming Soon', function () {
 			.first()
 			.contains( 'button', 'Launch' )
 			.should( 'exist' );
+
+	} );
+
+	it( 'Coming Soon Admin bar links to setting', () => {
+		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-coming-soon' ).click();
+		cy.location().should( ( loc ) => {
+			expect( loc.hash ).to.eq( '#/settings' )
+		});
+	} );
+
+	it( 'Coming Soon Toggle Turns Coming Soon Off', () => {
+		cy.visit(
+			'/wp-admin/admin.php?page=' +
+				Cypress.env( 'pluginId' ) +
+				'#/settings'
+		);
+		// Deactivate coming soon - Launch Site
+		cy.get( '[data-id="coming-soon-toggle"]' ).click();
+		cy.wait( 500 );
+
+		// Toggle is false
+		cy.get( '[data-id="coming-soon-toggle"]' )
+			.should( 'have.attr', 'aria-checked' )
+			.and( 'include', 'false' );
+
+		// Admin bar is updated
+		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-live' )
+			.scrollIntoView()
+			.should( 'be.visible' );
+
+		// Snackbar notice displays properly
+		cy.get( '.nfd-notifications' )
+			.contains( '.nfd-notification', 'Coming soon deactivated' )
+			.should( 'be.visible' );
+	} );
+
+	it( 'Coming Soon Toggle Turns Coming Soon On', () => {
+		cy.visit(
+			'/wp-admin/admin.php?page=' +
+				Cypress.env( 'pluginId' ) +
+				'#/settings'
+		);
+
+		// Activate Coming Soon - Unlaunch Site
+		cy.get( '[data-id="coming-soon-toggle"]' ).click();
+		cy.wait( 500 );
+
+		// Toggle is true
+		cy.get( '[data-id="coming-soon-toggle"]' )
+			.should( 'have.attr', 'aria-checked' )
+			.and( 'include', 'true' );
+
+		// Admin bar is updated
+		cy.get( '#wp-toolbar #wp-admin-bar-site-status #nfd-site-status-coming-soon' )
+			.scrollIntoView()
+			.should( 'be.visible' );
+
+		// Snackbar notice displays properly
+		cy.get( '.nfd-notifications' )
+			.contains( '.nfd-notification', 'Coming soon activated' )
+			.should( 'be.visible' );
 	} );
 
 	it( 'Displays admin coming soon notice', () => {
@@ -154,11 +188,6 @@ describe( 'Coming Soon', function () {
 		cy.get( '[data-id="coming-soon-toggle"]' )
 			.should( 'have.attr', 'aria-checked' )
 			.and( 'include', 'false' );
-		// Re-Activate Coming Soon
-		cy.get( '[data-id="coming-soon-toggle"]' ).click();
-		cy.wait( 500 );
-		cy.get( '[data-id="coming-soon-toggle"]' )
-			.should( 'have.attr', 'aria-checked' )
-			.and( 'include', 'true' );
+
 	} );
 } );


### PR DESCRIPTION
- rearrange and add some more tests to the suite for coming soon
- initial test just to check that the value was properly set via CLI
- broke tests into more individual entities as much as made sense
- added test for admin bar link
- left the step which reactivates coming soon at end of the test in case other tests rely on it

I think these updates will make the tests more independent.