### PR TITLE
Fix variable typo in coming-soon template

### DIFF
--- a/includes/template/index.php
+++ b/includes/template/index.php
@@ -77,7 +77,7 @@ $email_icon        = '<svg data-slot="icon" fill="none" stroke-width="1.5" strok
 				"@type": "WebSite",
 				"url": "<?php echo esc_url( site_url() ); ?>",
 				"name": "<?php echo esc_html( $args['template_page_title'] ); ?>",
-				"description": "<?php echo esc_html( $args['template_page_p'] ); ?>"
+				"description": "<?php echo esc_html( $args['template_p'] ); ?>"
 			}
 		</script>
 


### PR DESCRIPTION
## Proposed changes

This PR fixes a variable typo in coming-soon `index.php` template.
` PHP Warning:  Undefined array key "template_page_p"`

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [x] I have viewed my change in a web-browser
- [x] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
