### PR TITLE
chore(i18n): align Composer i18n scripts with WP-CLI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,9 +68,8 @@
       "@i18n-json",
       "@i18n-php"
     ],
-    "i18n-json": "find ./languages -name \"*.json\" -exec rm {} \\; && vendor/bin/wp i18n make-json ./languages --no-purge --pretty-print",
-    "i18n-mo": "vendor/bin/wp i18n make-mo ./languages",
-    "i18n-php": "vendor/bin/wp i18n make-php ./languages",
+    "i18n-json": "rm -f languages/*.json && vendor/bin/wp i18n make-json ./languages --pretty-print",
+    "i18n-php": "vendor/bin/wp i18n make-php ./languages --pretty-print",
     "i18n-po": "vendor/bin/wp i18n update-po ./languages/wp-module-coming-soon.pot ./languages",
     "i18n-pot": "vendor/bin/wp i18n make-pot . ./languages/wp-module-coming-soon.pot --domain=wp-module-coming-soon --headers='{\"Report-Msgid-Bugs-To\":\"https://github.com/newfold-labs/wp-module-coming-soon/issues\",\"POT-Creation-Date\":\"2025-02-13T09:55:55+00:00\"}' --exclude=wordpress,assets,tests,src",
     "lint": [
@@ -87,14 +86,13 @@
   },
   "scripts-descriptions": {
     "fix": "Automatically fix coding standards issues where possible.",
-    "i18n": "Generate translation files.",
-    "i18n-ci-pre": "Generate translation files for CI pre-commit.",
-    "i18n-ci-post": "Generate translation files for CI post-commit.",
-    "i18n-json": "Generate JSON translation files.",
-    "i18n-mo": "Generate MO translation files.",
-    "i18n-php": "Generate PHP translation files.",
-    "i18n-po": "Generate PO translation files.",
-    "i18n-pot": "Generate POT translation file.",
+    "i18n": "Run the full local i18n pipeline (POT, PO, PHP, JSON).",
+    "i18n-ci-pre": "CI: regenerate the POT file and sync PO catalogs from it.",
+    "i18n-ci-post": "CI: regenerate JED JSON and PHP translation files from PO catalogs.",
+    "i18n-json": "Remove stale JSON catalogs, then generate JED JSON from PO files using wp i18n make-json.",
+    "i18n-php": "Generate PHP translation files from PO files using wp i18n make-php.",
+    "i18n-po": "Update PO files from the POT file using wp i18n update-po.",
+    "i18n-pot": "Scan source and generate the POT translation template using wp i18n make-pot.",
     "lint": "Check files against coding standards.",
     "test": "Run tests.",
     "test-coverage": "Run tests with coverage, merge coverage and create HTML report."


### PR DESCRIPTION
## Summary
Pilot PR for the org-wide Composer i18n cleanup.

## Changes
- Remove deprecated `--no-purge` from `wp i18n make-json` (flag removed from WP-CLI i18n).
- Add `--pretty-print` to `wp i18n make-php`.
- Remove legacy `i18n-mo` / `make-mo` script (not used by reusable translations CI, which runs `i18n-ci-pre` / `i18n-ci-post`).
- Expand `scripts-descriptions` so every script has an accurate description (including CI vs local and explicit `wp i18n` subcommands).

## Verification
- `composer validate`
- `composer run-script --list` shows descriptions for all scripts.

## Related
- Uses `newfold-labs/workflows` reusable translations workflow; no workflow file changes required in this repo.

Made with [Cursor](https://cursor.com)