### PR TITLE
Fix Playwright E2E failures from WooCommerce lifecycle in shared brand env

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -59,23 +59,6 @@ async function installWooCommerce(page) {
 }
 
 /**
- * Uninstall WooCommerce and extensions
- */
-async function uninstallWooCommerce() {
-  try {
-    await wordpress.wpCli(
-      'plugin uninstall woocommerce --deactivate',
-      {
-        timeout: 20000,
-        failOnNonZeroExit: false,
-      }
-    );
-  } catch (error) {
-    fancyLog('Failed to uninstall WooCommerce:' + error.message, 55, 'yellow');
-  }
-}
-
-/**
  * Set coming soon option
  * 
  * @param {import('@playwright/test').Page} page - Playwright page object
@@ -423,7 +406,6 @@ export {
   // Coming Soon helpers
   removeWooCommerce,
   installWooCommerce,
-  uninstallWooCommerce,
   setComingSoonOption,
   navigateToSettings,
   navigateToHome,

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -31,7 +31,10 @@ const { setCapability } = newfold;
  */
 async function removeWooCommerce(page) {
   try {
-    await wordpress.wpCli('plugin uninstall woocommerce', {
+    // --deactivate: `wp plugin uninstall` refuses to remove an active plugin
+    // otherwise, so this is a no-op (logged, not thrown) if WooCommerce was
+    // left active by a previous local run.
+    await wordpress.wpCli('plugin uninstall woocommerce --deactivate', {
       timeout: 15000,
       failOnNonZeroExit: false,
     });

--- a/tests/playwright/specs/01-coming-soon.spec.mjs
+++ b/tests/playwright/specs/01-coming-soon.spec.mjs
@@ -16,6 +16,11 @@ import {
 // Use environment variable to resolve plugin helpers
 const pluginId = process.env.PLUGIN_ID || 'bluehost';
 
+// Runs before 02-coming-soon-woo.spec.mjs (enforced by the numeric filename
+// prefix): this suite needs WooCommerce absent, and the WooCommerce suite
+// intentionally leaves WooCommerce installed afterward rather than
+// deactivating it, since deactivating WooCommerce in the shared brand-plugin
+// test environment fatals other bundled plugins that assume it stays active.
 test.describe('Coming Soon', () => {
   const appClass = getAppClass();
 

--- a/tests/playwright/specs/02-coming-soon-woo.spec.mjs
+++ b/tests/playwright/specs/02-coming-soon-woo.spec.mjs
@@ -12,7 +12,6 @@ import {
   enableComingSoon,
   disableComingSoon,
   verifySitePreviewWarningHidden,
-  uninstallWooCommerce,
 } from '../helpers';
 
 // Use environment variable to resolve plugin helpers
@@ -51,12 +50,11 @@ test.describe('Coming Soon with WooCommerce', () => {
     }
   });
 
-  test.afterAll(async () => {
-    // Only uninstall if we installed it
-    if (wooSupported) {
-      await uninstallWooCommerce();
-    }
-  });
+  // Intentionally no afterAll teardown: this is the last coming-soon suite to
+  // run (see numeric filename prefix), and deactivating/uninstalling
+  // WooCommerce here fatals other plugins in the shared brand-plugin test
+  // environment that assume WooCommerce stays active once installed, which
+  // in turn breaks wp-login.php for every test that runs afterward.
 
   test("Replace our admin bar site status badge with WooCommerce's when active", async ({ page }) => {
     // Skip if WooCommerce is not supported in this environment


### PR DESCRIPTION
## Summary

Dependabot PRs (e.g. #290) and even fresh runs of `main` have been failing the "Bluehost Build and Test" Playwright jobs. All 5 tests in `coming-soon.spec.mjs` fail with `page.fill: Test timeout of 30000ms exceeded` while waiting for `#user_login` — i.e. the login page itself never renders.

### Root cause

The full job log (`debug.log` dump) shows the WordPress site fataling on every request:

```
PHP Fatal error: Uncaught Error: Class "WC_Data_Store" not found in
.../wp-plugin-payments-shipping/modules/stripe/includes/Connect/ConnectWebhook.php:43
```

This "brand plugin" CI workflow builds the full Bluehost plugin stack, including companion plugins (like `wp-plugin-payments-shipping`) that are always active in that environment and assume WooCommerce stays active once installed. Our own Playwright suite installs WooCommerce (`coming-soon-woo.spec.mjs`, for the "WooCommerce present" scenario) and then deactivates/uninstalls it in `afterAll` — and that deactivation is what fatals the unrelated Stripe module for the rest of the job, breaking `wp-login.php` (and therefore every later test's login step) sitewide.

Confirmed by the job's own numbers: "3 passed" (the WooCommerce suite, run first alphabetically) followed immediately by "5 failed" (the plain suite, run second) — the failures start exactly at the point WooCommerce gets deactivated.

`wp-plugin-payments-shipping` isn't a repo we maintain here, so we can't patch its missing `class_exists('WC_Data_Store')` guard directly. This PR instead avoids ever triggering it from our own tests.

### Changes

- Renamed spec files with numeric prefixes (`01-coming-soon.spec.mjs`, `02-coming-soon-woo.spec.mjs`) so the "WooCommerce absent" suite is guaranteed to run *before* the "WooCommerce present" suite (Playwright runs spec files sequentially here since `workers: 1` is forced in CI).
- Removed the `afterAll` WooCommerce teardown in the WooCommerce suite — it's now the last suite to run, so nothing downstream needs WooCommerce removed, and removing it is exactly what broke the shared environment.
- Added `--deactivate` to `removeWooCommerce()`'s wp-cli command so it still works correctly if WooCommerce was left active by a previous local run (it was missing the flag `wp plugin uninstall` needs to remove an active plugin).

A companion fix in `wp-plugin-bluehost` (same branch name) addresses a related latent bug where `wpCli()` silently dropped the `timeout`/`failOnNonZeroExit` options every caller in this suite already passes.

## Test plan

- [ ] CI: "Bluehost Build and Test Cypress" and "Bluehost Dev Build and Test Playwright" jobs pass on this PR
- [x] Verified new spec filenames aren't referenced elsewhere (docs, project configs) — discovery is glob-based (`*.spec.{js,mjs}`)
- [x] `node --check` on all edited files


---
_Generated by [Claude Code](https://claude.ai/code/session_016SMeiLMysC9rZ488fAKLJD)_