### PR TITLE
Reuse plugin-level WooCommerce install/uninstall helper

### DIFF
--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -20,17 +20,17 @@ const helpersUrl = pathToFileURL(finalHelpersPath).href;
 const pluginHelpers = await import(helpersUrl);
 
 // Destructure plugin helpers
-let { auth, wordpress, newfold, a11y, utils, woocommerce } = pluginHelpers;
+let { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
 const { fancyLog } = utils;
 const { setCapability } = newfold;
 
 /**
  * Install/uninstall helpers for WooCommerce (shared, defined at the plugin level in
- * tests/playwright/helpers/woocommerce.mjs so every module reuses the same implementation,
+ * tests/playwright/helpers/newfold.mjs so every module reuses the same implementation,
  * which also deactivates known WooCommerce-dependent companion plugins on uninstall).
  * `removeWooCommerce` is kept as an alias of `uninstallWooCommerce` for existing callers.
  */
-const { installWooCommerce, uninstallWooCommerce } = woocommerce;
+const { installWooCommerce, uninstallWooCommerce } = newfold;
 const removeWooCommerce = uninstallWooCommerce;
 
 /**

--- a/tests/playwright/helpers/index.mjs
+++ b/tests/playwright/helpers/index.mjs
@@ -20,43 +20,18 @@ const helpersUrl = pathToFileURL(finalHelpersPath).href;
 const pluginHelpers = await import(helpersUrl);
 
 // Destructure plugin helpers
-let { auth, wordpress, newfold, a11y, utils } = pluginHelpers;
+let { auth, wordpress, newfold, a11y, utils, woocommerce } = pluginHelpers;
 const { fancyLog } = utils;
 const { setCapability } = newfold;
 
 /**
- * Remove WooCommerce plugin
- * 
- * @param {import('@playwright/test').Page} page - Playwright page object
+ * Install/uninstall helpers for WooCommerce (shared, defined at the plugin level in
+ * tests/playwright/helpers/woocommerce.mjs so every module reuses the same implementation,
+ * which also deactivates known WooCommerce-dependent companion plugins on uninstall).
+ * `removeWooCommerce` is kept as an alias of `uninstallWooCommerce` for existing callers.
  */
-async function removeWooCommerce(page) {
-  try {
-    // --deactivate: `wp plugin uninstall` refuses to remove an active plugin
-    // otherwise, so this is a no-op (logged, not thrown) if WooCommerce was
-    // left active by a previous local run.
-    await wordpress.wpCli('plugin uninstall woocommerce --deactivate', {
-      timeout: 15000,
-      failOnNonZeroExit: false,
-    });
-  } catch (error) {
-    fancyLog('Failed to remove WooCommerce:' + error.message, 55, 'yellow');
-  }
-}
-
-/**
- * Install and activate WooCommerce plugin
- * 
- * @param {import('@playwright/test').Page} page - Playwright page object
- */
-async function installWooCommerce(page) {
-  try {
-    await wordpress.wpCli('plugin install woocommerce --activate', {
-      timeout: 15000,
-    });
-  } catch (error) {
-    fancyLog('Failed to install WooCommerce:' + error.message, 55, 'yellow');
-  }
-}
+const { installWooCommerce, uninstallWooCommerce } = woocommerce;
+const removeWooCommerce = uninstallWooCommerce;
 
 /**
  * Set coming soon option


### PR DESCRIPTION
## Summary
- `installWooCommerce`/`uninstallWooCommerce` (and the `removeWooCommerce` alias) are now re-exported from the host plugin's shared `newfold` helper instead of being defined locally.

## Why
This logic was duplicated between here and `wp-module-ecommerce`, and neither cleaned up companion plugins that assume WooCommerce stays active once installed — see the teardown comment in `tests/playwright/specs/02-coming-soon-woo.spec.mjs`, which currently avoids uninstalling WooCommerce at all for exactly this reason. The shared implementation (added in newfold-labs/wp-plugin-bluehost#1368, in `tests/playwright/helpers/newfold.mjs` alongside the other third-party plugin integration helpers) also deactivates known WooCommerce-dependent plugins (e.g. `wp-plugin-payments-shipping`) on uninstall, since one of those fataling on `WC_Data_Store` after WooCommerce is removed was cascading into unrelated Playwright failures across the WP 6.9/7.0 test matrix.

## Depends on
Requires a host plugin whose `tests/playwright/helpers/newfold.mjs` exports `installWooCommerce`/`isWooCommerceActive`/`uninstallWooCommerce` — see newfold-labs/wp-plugin-bluehost#1368. Should merge after (or alongside) that PR; the host plugin's composer.lock also needs to be bumped to pick this module version up in its own e2e runs.

## Test plan
- [ ] Run this module's Playwright suite against a host plugin build that includes the updated `newfold.mjs` helper.